### PR TITLE
Adapt build-host variable for gplay in build.gradle.kts (fixes #4 )

### DIFF
--- a/syncthing/build.gradle.kts
+++ b/syncthing/build.gradle.kts
@@ -63,7 +63,7 @@ tasks.register("buildNative") {
         val env = mapOf(
             "NDK_VERSION" to libs.versions.ndk.version.get(),
             "SOURCE_DATE_EPOCH" to getSourceDateEpoch(execOps),
-            "BUILD_HOST" to "Catfriend1-syncthing-android",
+            "BUILD_HOST" to "nel0x-syncthing-android-gplay",
             "BUILD_USER" to "reproducible-build",
             "STTRACE" to ""
         )


### PR DESCRIPTION
# Description
Fixes the build-host variable for gplay release (for correct assignment in Grafana monitoring / logs)

Fixes #4 

